### PR TITLE
Randomize form spawn positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Here's your live rig cheat sheet—no mysteries, just hot keys:
 * `S` – grab a `saveFrame()` screenshot.
 * `I` – hide or show the on-screen help box squatting in the lower-right 250×250 patch.
 
-Shapes now burst into existence dead-center before wandering off like caffeinated fireflies.
+Shapes now pop in from jittery starting points all over the field—never jailed in one corner—before wandering off like caffeinated fireflies.
 
 As each form ages it feels the tug of an invisible galactic drain.  The closer it gets to dying, the harder it's yanked toward the nearest edge.  Smack into the boundary and it goes supernova, spraying a cloud of tiny motes whose count nods to the form's own vertex guts.  Those motes chill out over time, drifting into a hazy floor that hangs behind the action so the whole mess has a ghostly ground to stomp on.
 

--- a/glitchListen/glitchListen.pde
+++ b/glitchListen/glitchListen.pde
@@ -546,7 +546,7 @@ abstract class GlitchForm {
   float born   = millis();
   float lifeMs = random(400, 1700);
 
-  // Start dead-center; jitter will sling them around after birth
+  // Start somewhere around the screen with a bit of initial drift
   float x = 0;
   float y = 0;
   float vx = 0;
@@ -567,6 +567,16 @@ abstract class GlitchForm {
   int strokeCol = color(255);
   int fillCol   = color(255, 20);
   boolean additive = random(1) < 0.6; // choose ADD vs SCREEN blending
+
+  GlitchForm() {
+    // Randomize spawn away from corners so we don't cluster bottom-right again
+    float rx = width * 0.4f;
+    float ry = height * 0.4f;
+    x = random(-rx, rx);
+    y = random(-ry, ry);
+    vx = random(-2, 2);
+    vy = random(-2, 2);
+  }
 
   // Called each frame with fresh audio features
   void update(float rms, float bass, float mid, float high, float centroid, boolean onset) {


### PR DESCRIPTION
## Summary
- Spawn new glitch forms at randomized screen positions with a dab of initial velocity so they don't huddle in the lower-right
- Document the wilder spawn behavior in the README

## Testing
- `processing-java --sketch=glitchListen --build` *(fails: command not found)*
- `apt-get update` *(fails: repo InRelease not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf307d78d48325bf07b7a89ce6463a