### PR TITLE
FFT-based spawns with 16-form ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Here's your live rig cheat sheet—no mysteries, just hot keys:
 
 Shapes now pop in from jittery starting points all over the field—never jailed in one corner—before wandering off like caffeinated fireflies.
 
+### How the chaos triggers
+
+An FFT chews up the incoming sound and watches the bass, mids, and highs. When any band spikes hard enough, a form tied to that part of the spectrum barges in. Bass hits birth chunky polygons, mids swirl donuts or splines, and highs scribble wiry Lissajous loops. The stage now allows up to **16** forms at once so no riff gets left behind.
+
 As each form ages it feels the tug of an invisible galactic drain.  The closer it gets to dying, the harder it's yanked toward the nearest edge.  Smack into the boundary and it goes supernova, spraying a cloud of tiny motes whose count nods to the form's own vertex guts.  Those motes chill out over time, drifting into a hazy floor that hangs behind the action so the whole mess has a ghostly ground to stomp on.
 
 ## Closing time

--- a/glitchListen/data/preset_20250908_131740.json
+++ b/glitchListen/data/preset_20250908_131740.json
@@ -5,7 +5,7 @@
   "strobeIntensity": 0.6499999761581421,
   "doRGBShift": true,
   "doFadeFloor": true,
-  "maxForms": 4,
+  "maxForms": 16,
   "doFeedback": true,
   "strobeOn": true,
   "fbAmount": 1,

--- a/glitchListen/data/preset_20250908_131741.json
+++ b/glitchListen/data/preset_20250908_131741.json
@@ -5,7 +5,7 @@
   "strobeIntensity": 0.6499999761581421,
   "doRGBShift": true,
   "doFadeFloor": true,
-  "maxForms": 4,
+  "maxForms": 16,
   "doFeedback": true,
   "strobeOn": true,
   "fbAmount": 1,

--- a/glitchListen/glitchListen1261965432988459467.autosave
+++ b/glitchListen/glitchListen1261965432988459467.autosave
@@ -70,7 +70,7 @@ float smoothedHigh = 0;
 
 // ── Visual / State Globals ───────────────────────────────────────────────────
 ArrayList<GlitchForm> forms = new ArrayList<GlitchForm>(); // active geometry
-int maxForms = 4;                                          // cap the chaos
+int maxForms = 16;                                         // cap the chaos (overkill but keeps every beat)
 
 // Offscreen buffers for effects
 PGraphics fb;          // framebuffer used for feedback smear
@@ -264,12 +264,19 @@ void analyzeAudio() {
 
 // ── SPAWNING: create new geometry instances when the sound “bursts” ─────────
 void maybeSpawn() {
-  // Burst condition: a detected onset OR big spectral change OR high RMS
-  boolean burst = beat.isOnset() || spectralFlux > 0.45 || rms > 0.18;
+  // Use FFT band energy: if any bucket punches hard, pop a form.
+  boolean bassHit = smoothedBass > 0.3;
+  boolean midHit  = smoothedMid  > 0.25;
+  boolean highHit = smoothedHigh > 0.2;
+
+  int band = -1; // 0=bass,1=mid,2=high
+  if (bassHit && smoothedBass >= max(smoothedMid, smoothedHigh)) band = 0;
+  else if (midHit && smoothedMid >= smoothedHigh)               band = 1;
+  else if (highHit)                                             band = 2;
 
   // Rate-limit spawns so we don’t overwhelm the frame every single tick.
-  if (burst && frameCount - lastSpawnFrame > minSpawnGapFrames) {
-    spawnForm();
+  if (band >= 0 && frameCount - lastSpawnFrame > minSpawnGapFrames) {
+    spawnForm(band);
     lastSpawnFrame = frameCount;
   }
 
@@ -277,16 +284,32 @@ void maybeSpawn() {
   while (forms.size() > maxForms) forms.remove(0);
 }
 
-// Create a randomly chosen form type and add it to the list.
-void spawnForm() {
-  int choice = (int)random(5); // 5 types below
+// Default random spawn used by manual triggers/OSC
+void spawnForm() { spawnForm(-1); }
+
+// Spawn a form tuned to the frequency band that begged for attention
+void spawnForm(int band) {
   GlitchForm f;
-  switch (choice) {
-    case 0: f = new PolygonBurst();  break;
-    case 1: f = new WireLissajous(); break;
-    case 2: f = new NoisyDonut();    break;
-    case 3: f = new TriStripWeave(); break;
-    default:f = new SpiroSpline();   break;
+  switch (band) {
+    case 0: // Bass: big chunky shapes
+      f = random(1) < 0.5 ? new PolygonBurst() : new TriStripWeave();
+      break;
+    case 1: // Midrange: rounders and splines
+      f = random(1) < 0.5 ? new NoisyDonut() : new SpiroSpline();
+      break;
+    case 2: // Highs: wiry scribbles
+      f = new WireLissajous();
+      break;
+    default: // Fall back to full random chaos
+      int choice = (int)random(5);
+      switch (choice) {
+        case 0: f = new PolygonBurst();  break;
+        case 1: f = new WireLissajous(); break;
+        case 2: f = new NoisyDonut();    break;
+        case 3: f = new TriStripWeave(); break;
+        default:f = new SpiroSpline();   break;
+      }
+      break;
   }
   forms.add(f);
 }


### PR DESCRIPTION
## Summary
- Let the FFT lead: spawn logic now listens for bass/mid/high surges and launches forms tied to those bands.
- Cranked maxForms to 16 so no juicy transient slips by.
- Documented the FFT-driven chaos in the README.

## Testing
- `processing-java --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3fd88ddc8325b63f5532f8e80aff